### PR TITLE
Add backend controllers validators and routes

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -1,3 +1,5 @@
+import express from 'express';
+
 export { connectToDatabase, disconnectFromDatabase } from './config/database.js';
 export {
   AccountDataModel,
@@ -5,3 +7,24 @@ export {
   GameModel,
   UserModel
 } from './models/index.js';
+export { accountDataRouter } from './routes/account-data.routes.js';
+export { friendsRouter } from './routes/friends.routes.js';
+export { gameRouter } from './routes/game.routes.js';
+export { userRouter } from './routes/user.routes.js';
+
+/**
+ * Creates the backend Express application and mounts all API routes.
+ *
+ * @returns {express.Express} Configured Express application instance.
+ */
+export function createApp() {
+  const application = express();
+
+  application.use(express.json());
+  application.use('/api/users', userRouter);
+  application.use('/api/account-data', accountDataRouter);
+  application.use('/api/friends', friendsRouter);
+  application.use('/api/games', gameRouter);
+
+  return application;
+}

--- a/backend/controllers/account-data.controller.ts
+++ b/backend/controllers/account-data.controller.ts
@@ -1,0 +1,145 @@
+import type { Request, Response } from 'express';
+import mongoose from 'mongoose';
+
+import { AccountDataModel } from '../models/account-data.model.js';
+
+/**
+ * Creates account data for a user.
+ *
+ * @param {Request} request - Express request containing validated account data.
+ * @param {Response} response - Express response for the created account record.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function createAccountData(request: Request, response: Response) {
+  try {
+    const accountData = await AccountDataModel.create(request.body);
+    response.status(201).json(accountData);
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Lists all account data records.
+ *
+ * @param {Request} _request - Unused Express request object.
+ * @param {Response} response - Express response for the list payload.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function listAccountData(_request: Request, response: Response) {
+  try {
+    const records = await AccountDataModel.find().lean();
+    response.status(200).json(records);
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Fetches one account data record by identifier.
+ *
+ * @param {Request} request - Express request containing a validated `id` param.
+ * @param {Response} response - Express response for the fetched account record.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function getAccountDataById(request: Request, response: Response) {
+  try {
+    const accountData = await AccountDataModel.findById(request.params.id).lean();
+
+    if (!accountData) {
+      response.status(404).json({ error: 'Account data not found.' });
+      return;
+    }
+
+    response.status(200).json(accountData);
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Updates one account data record.
+ *
+ * @param {Request} request - Express request containing a validated `id` and body.
+ * @param {Response} response - Express response for the updated record.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function updateAccountData(request: Request, response: Response) {
+  try {
+    const accountData = await AccountDataModel.findByIdAndUpdate(
+      request.params.id,
+      request.body,
+      {
+        new: true,
+        runValidators: true
+      }
+    ).lean();
+
+    if (!accountData) {
+      response.status(404).json({ error: 'Account data not found.' });
+      return;
+    }
+
+    response.status(200).json(accountData);
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Deletes one account data record.
+ *
+ * @param {Request} request - Express request containing a validated `id` param.
+ * @param {Response} response - Express response for the deletion result.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function deleteAccountData(request: Request, response: Response) {
+  try {
+    const accountData = await AccountDataModel.findByIdAndDelete(request.params.id).lean();
+
+    if (!accountData) {
+      response.status(404).json({ error: 'Account data not found.' });
+      return;
+    }
+
+    response.status(200).json({ message: 'Account data deleted successfully.' });
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Maps known account-data persistence errors to API responses.
+ *
+ * @param {unknown} error - Error thrown during controller execution.
+ * @param {Response} response - Express response instance.
+ * @returns {void}
+ */
+function handleControllerError(error: unknown, response: Response) {
+  if (error instanceof mongoose.Error.ValidationError) {
+    response.status(400).json({ error: error.message });
+    return;
+  }
+
+  if (isDuplicateKeyError(error)) {
+    response.status(409).json({ error: 'Account data already exists for that user.' });
+    return;
+  }
+
+  response.status(500).json({ error: 'Unable to process account data request.' });
+}
+
+/**
+ * Checks whether the error is a Mongo duplicate key failure.
+ *
+ * @param {unknown} error - Unknown thrown error.
+ * @returns {boolean} True when the error matches code 11000.
+ */
+function isDuplicateKeyError(error: unknown) {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 11000
+  );
+}

--- a/backend/controllers/friends.controller.ts
+++ b/backend/controllers/friends.controller.ts
@@ -1,0 +1,145 @@
+import type { Request, Response } from 'express';
+import mongoose from 'mongoose';
+
+import { FriendsModel } from '../models/friends.model.js';
+
+/**
+ * Creates a friend list document for a user.
+ *
+ * @param {Request} request - Express request containing validated friend-list data.
+ * @param {Response} response - Express response for the created friend list.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function createFriendsList(request: Request, response: Response) {
+  try {
+    const friendsList = await FriendsModel.create(request.body);
+    response.status(201).json(friendsList);
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Lists all friend list documents.
+ *
+ * @param {Request} _request - Unused Express request object.
+ * @param {Response} response - Express response for the list payload.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function listFriendsLists(_request: Request, response: Response) {
+  try {
+    const friendLists = await FriendsModel.find().lean();
+    response.status(200).json(friendLists);
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Fetches one friend list by identifier.
+ *
+ * @param {Request} request - Express request containing a validated `id` param.
+ * @param {Response} response - Express response for the friend list payload.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function getFriendsListById(request: Request, response: Response) {
+  try {
+    const friendList = await FriendsModel.findById(request.params.id).lean();
+
+    if (!friendList) {
+      response.status(404).json({ error: 'Friends list not found.' });
+      return;
+    }
+
+    response.status(200).json(friendList);
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Updates one friend list document.
+ *
+ * @param {Request} request - Express request containing a validated `id` and body.
+ * @param {Response} response - Express response for the updated friend list.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function updateFriendsList(request: Request, response: Response) {
+  try {
+    const friendList = await FriendsModel.findByIdAndUpdate(
+      request.params.id,
+      request.body,
+      {
+        new: true,
+        runValidators: true
+      }
+    ).lean();
+
+    if (!friendList) {
+      response.status(404).json({ error: 'Friends list not found.' });
+      return;
+    }
+
+    response.status(200).json(friendList);
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Deletes one friend list document.
+ *
+ * @param {Request} request - Express request containing a validated `id` param.
+ * @param {Response} response - Express response for the deletion result.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function deleteFriendsList(request: Request, response: Response) {
+  try {
+    const friendList = await FriendsModel.findByIdAndDelete(request.params.id).lean();
+
+    if (!friendList) {
+      response.status(404).json({ error: 'Friends list not found.' });
+      return;
+    }
+
+    response.status(200).json({ message: 'Friends list deleted successfully.' });
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Maps known friend-list persistence errors to API responses.
+ *
+ * @param {unknown} error - Error thrown during controller execution.
+ * @param {Response} response - Express response instance.
+ * @returns {void}
+ */
+function handleControllerError(error: unknown, response: Response) {
+  if (error instanceof mongoose.Error.ValidationError) {
+    response.status(400).json({ error: error.message });
+    return;
+  }
+
+  if (isDuplicateKeyError(error)) {
+    response.status(409).json({ error: 'Friends list already exists for that user.' });
+    return;
+  }
+
+  response.status(500).json({ error: 'Unable to process friends request.' });
+}
+
+/**
+ * Checks whether the error is a Mongo duplicate key failure.
+ *
+ * @param {unknown} error - Unknown thrown error.
+ * @returns {boolean} True when the error matches code 11000.
+ */
+function isDuplicateKeyError(error: unknown) {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 11000
+  );
+}

--- a/backend/controllers/game.controller.ts
+++ b/backend/controllers/game.controller.ts
@@ -1,0 +1,121 @@
+import type { Request, Response } from 'express';
+import mongoose from 'mongoose';
+
+import { GameModel } from '../models/game.model.js';
+
+/**
+ * Creates a game history record.
+ *
+ * @param {Request} request - Express request containing validated game data.
+ * @param {Response} response - Express response for the created game record.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function createGame(request: Request, response: Response) {
+  try {
+    const game = await GameModel.create(request.body);
+    response.status(201).json(game);
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Lists all game records.
+ *
+ * @param {Request} _request - Unused Express request object.
+ * @param {Response} response - Express response for the list payload.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function listGames(_request: Request, response: Response) {
+  try {
+    const games = await GameModel.find().lean();
+    response.status(200).json(games);
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Fetches one game record by identifier.
+ *
+ * @param {Request} request - Express request containing a validated `id` param.
+ * @param {Response} response - Express response for the game payload.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function getGameById(request: Request, response: Response) {
+  try {
+    const game = await GameModel.findById(request.params.id).lean();
+
+    if (!game) {
+      response.status(404).json({ error: 'Game not found.' });
+      return;
+    }
+
+    response.status(200).json(game);
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Updates one game record.
+ *
+ * @param {Request} request - Express request containing a validated `id` and body.
+ * @param {Response} response - Express response for the updated game record.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function updateGame(request: Request, response: Response) {
+  try {
+    const game = await GameModel.findByIdAndUpdate(request.params.id, request.body, {
+      new: true,
+      runValidators: true
+    }).lean();
+
+    if (!game) {
+      response.status(404).json({ error: 'Game not found.' });
+      return;
+    }
+
+    response.status(200).json(game);
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Deletes one game record.
+ *
+ * @param {Request} request - Express request containing a validated `id` param.
+ * @param {Response} response - Express response for the deletion result.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function deleteGame(request: Request, response: Response) {
+  try {
+    const game = await GameModel.findByIdAndDelete(request.params.id).lean();
+
+    if (!game) {
+      response.status(404).json({ error: 'Game not found.' });
+      return;
+    }
+
+    response.status(200).json({ message: 'Game deleted successfully.' });
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Maps known game persistence errors to API responses.
+ *
+ * @param {unknown} error - Error thrown during controller execution.
+ * @param {Response} response - Express response instance.
+ * @returns {void}
+ */
+function handleControllerError(error: unknown, response: Response) {
+  if (error instanceof mongoose.Error.ValidationError) {
+    response.status(400).json({ error: error.message });
+    return;
+  }
+
+  response.status(500).json({ error: 'Unable to process game request.' });
+}

--- a/backend/controllers/user.controller.ts
+++ b/backend/controllers/user.controller.ts
@@ -1,0 +1,185 @@
+import type { Request, Response } from 'express';
+import mongoose from 'mongoose';
+
+import { UserModel } from '../models/user.model.js';
+
+/**
+ * Creates a new user account document.
+ *
+ * @param {Request} request - Express request containing validated user input.
+ * @param {Response} response - Express response used to return the created user.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function createUser(request: Request, response: Response) {
+  try {
+    const user = new UserModel({
+      name: request.body.name,
+      displayName: request.body.displayName,
+      dateOfBirth: request.body.dateOfBirth,
+      email: request.body.email
+    });
+
+    user.set('password', request.body.password);
+
+    await user.save();
+
+    response.status(201).json({
+      id: user.id,
+      name: user.name,
+      displayName: user.displayName,
+      dateOfBirth: user.dateOfBirth,
+      email: user.email
+    });
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Lists all user documents.
+ *
+ * @param {Request} _request - Unused Express request object.
+ * @param {Response} response - Express response for the user list.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function listUsers(_request: Request, response: Response) {
+  try {
+    const users = await UserModel.find().select('-passwordHash').lean();
+
+    response.status(200).json(users);
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Fetches one user by MongoDB identifier.
+ *
+ * @param {Request} request - Express request containing a validated `id` param.
+ * @param {Response} response - Express response for the user payload.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function getUserById(request: Request, response: Response) {
+  try {
+    const user = await UserModel.findById(request.params.id)
+      .select('-passwordHash')
+      .lean();
+
+    if (!user) {
+      response.status(404).json({ error: 'User not found.' });
+      return;
+    }
+
+    response.status(200).json(user);
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Updates a user document with validated input.
+ *
+ * @param {Request} request - Express request containing `id` and allowed fields.
+ * @param {Response} response - Express response for the updated user.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function updateUser(request: Request, response: Response) {
+  try {
+    const user = await UserModel.findById(request.params.id);
+
+    if (!user) {
+      response.status(404).json({ error: 'User not found.' });
+      return;
+    }
+
+    if (request.body.name !== undefined) {
+      user.name = request.body.name;
+    }
+
+    if (request.body.displayName !== undefined) {
+      user.displayName = request.body.displayName;
+    }
+
+    if (request.body.dateOfBirth !== undefined) {
+      user.dateOfBirth = request.body.dateOfBirth;
+    }
+
+    if (request.body.email !== undefined) {
+      user.email = request.body.email;
+    }
+
+    if (request.body.password !== undefined) {
+      user.set('password', request.body.password);
+    }
+
+    await user.save();
+
+    response.status(200).json({
+      id: user.id,
+      name: user.name,
+      displayName: user.displayName,
+      dateOfBirth: user.dateOfBirth,
+      email: user.email
+    });
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Deletes a user document by identifier.
+ *
+ * @param {Request} request - Express request containing a validated `id` param.
+ * @param {Response} response - Express response for the deletion result.
+ * @returns {Promise<void>} Promise resolved after the response is sent.
+ */
+export async function deleteUser(request: Request, response: Response) {
+  try {
+    const deletedUser = await UserModel.findByIdAndDelete(request.params.id).lean();
+
+    if (!deletedUser) {
+      response.status(404).json({ error: 'User not found.' });
+      return;
+    }
+
+    response.status(200).json({ message: 'User deleted successfully.' });
+  } catch (error) {
+    handleControllerError(error, response);
+  }
+}
+
+/**
+ * Maps known persistence errors to API responses.
+ *
+ * @param {unknown} error - Error thrown during controller execution.
+ * @param {Response} response - Express response instance.
+ * @returns {void}
+ */
+function handleControllerError(error: unknown, response: Response) {
+  if (error instanceof mongoose.Error.ValidationError) {
+    response.status(400).json({ error: error.message });
+    return;
+  }
+
+  if (isDuplicateKeyError(error)) {
+    response.status(409).json({ error: 'A user with that email already exists.' });
+    return;
+  }
+
+  response.status(500).json({ error: 'Unable to process user request.' });
+}
+
+/**
+ * Checks whether the error is a Mongo duplicate key failure.
+ *
+ * @param {unknown} error - Unknown thrown error.
+ * @returns {boolean} True when the error matches code 11000.
+ */
+function isDuplicateKeyError(error: unknown) {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 11000
+  );
+}

--- a/backend/routes/account-data.routes.ts
+++ b/backend/routes/account-data.routes.ts
@@ -1,0 +1,27 @@
+import { Router } from 'express';
+
+import {
+  createAccountData,
+  deleteAccountData,
+  getAccountDataById,
+  listAccountData,
+  updateAccountData
+} from '../controllers/account-data.controller.js';
+import {
+  validateAccountDataId,
+  validateCreateAccountData,
+  validateUpdateAccountData
+} from '../validators/account-data.validator.js';
+
+export const accountDataRouter = Router();
+
+accountDataRouter.get('/', listAccountData);
+accountDataRouter.get('/:id', validateAccountDataId, getAccountDataById);
+accountDataRouter.post('/', validateCreateAccountData, createAccountData);
+accountDataRouter.put(
+  '/:id',
+  validateAccountDataId,
+  validateUpdateAccountData,
+  updateAccountData
+);
+accountDataRouter.delete('/:id', validateAccountDataId, deleteAccountData);

--- a/backend/routes/friends.routes.ts
+++ b/backend/routes/friends.routes.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+
+import {
+  createFriendsList,
+  deleteFriendsList,
+  getFriendsListById,
+  listFriendsLists,
+  updateFriendsList
+} from '../controllers/friends.controller.js';
+import {
+  validateCreateFriends,
+  validateFriendsId,
+  validateUpdateFriends
+} from '../validators/friends.validator.js';
+
+export const friendsRouter = Router();
+
+friendsRouter.get('/', listFriendsLists);
+friendsRouter.get('/:id', validateFriendsId, getFriendsListById);
+friendsRouter.post('/', validateCreateFriends, createFriendsList);
+friendsRouter.put('/:id', validateFriendsId, validateUpdateFriends, updateFriendsList);
+friendsRouter.delete('/:id', validateFriendsId, deleteFriendsList);

--- a/backend/routes/game.routes.ts
+++ b/backend/routes/game.routes.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+
+import {
+  createGame,
+  deleteGame,
+  getGameById,
+  listGames,
+  updateGame
+} from '../controllers/game.controller.js';
+import {
+  validateCreateGame,
+  validateGameId,
+  validateUpdateGame
+} from '../validators/game.validator.js';
+
+export const gameRouter = Router();
+
+gameRouter.get('/', listGames);
+gameRouter.get('/:id', validateGameId, getGameById);
+gameRouter.post('/', validateCreateGame, createGame);
+gameRouter.put('/:id', validateGameId, validateUpdateGame, updateGame);
+gameRouter.delete('/:id', validateGameId, deleteGame);

--- a/backend/routes/user.routes.ts
+++ b/backend/routes/user.routes.ts
@@ -1,0 +1,22 @@
+import { Router } from 'express';
+
+import {
+  createUser,
+  deleteUser,
+  getUserById,
+  listUsers,
+  updateUser
+} from '../controllers/user.controller.js';
+import {
+  validateCreateUser,
+  validateMongoId,
+  validateUpdateUser
+} from '../validators/user.validator.js';
+
+export const userRouter = Router();
+
+userRouter.get('/', listUsers);
+userRouter.get('/:id', validateMongoId, getUserById);
+userRouter.post('/', validateCreateUser, createUser);
+userRouter.put('/:id', validateMongoId, validateUpdateUser, updateUser);
+userRouter.delete('/:id', validateMongoId, deleteUser);

--- a/backend/validators/account-data.validator.ts
+++ b/backend/validators/account-data.validator.ts
@@ -1,0 +1,167 @@
+import type { NextFunction, Request, Response } from 'express';
+import mongoose from 'mongoose';
+
+/**
+ * Validates the request body used to create account data.
+ *
+ * @param {Request} request - Express request containing account data fields.
+ * @param {Response} response - Express response used for validation failures.
+ * @param {NextFunction} next - Express continuation callback.
+ * @returns {void}
+ */
+export function validateCreateAccountData(
+  request: Request,
+  response: Response,
+  next: NextFunction
+) {
+  const {
+    currentUser,
+    currentBalance,
+    cosmeticCurrency,
+    currentDailyStreakCount,
+    longestStreakCount
+  } = request.body;
+
+  if (!mongoose.isValidObjectId(currentUser)) {
+    response.status(400).json({ error: 'Current user must be a valid MongoDB identifier.' });
+    return;
+  }
+
+  if (!isNonNegativeIntegerOrNumber(currentBalance)) {
+    response.status(400).json({ error: 'Current balance must be a non-negative number.' });
+    return;
+  }
+
+  if (!isNonNegativeIntegerOrNumber(cosmeticCurrency)) {
+    response.status(400).json({ error: 'Cosmetic currency must be a non-negative number.' });
+    return;
+  }
+
+  if (!isNonNegativeIntegerOrNumber(currentDailyStreakCount)) {
+    response.status(400).json({ error: 'Current daily streak count must be non-negative.' });
+    return;
+  }
+
+  if (!isNonNegativeIntegerOrNumber(longestStreakCount)) {
+    response.status(400).json({ error: 'Longest streak count must be non-negative.' });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Validates the request body used to update account data.
+ *
+ * @param {Request} request - Express request containing partial account fields.
+ * @param {Response} response - Express response used for validation failures.
+ * @param {NextFunction} next - Express continuation callback.
+ * @returns {void}
+ */
+export function validateUpdateAccountData(
+  request: Request,
+  response: Response,
+  next: NextFunction
+) {
+  const allowedKeys = [
+    'currentUser',
+    'currentBalance',
+    'cosmeticCurrency',
+    'currentDailyStreakCount',
+    'longestStreakCount'
+  ];
+
+  if (!hasSupportedKeys(request.body, allowedKeys)) {
+    response.status(400).json({ error: 'Request contains unsupported account data fields.' });
+    return;
+  }
+
+  if (Object.keys(request.body).length === 0) {
+    response.status(400).json({ error: 'At least one account data field is required.' });
+    return;
+  }
+
+  if (
+    request.body.currentUser !== undefined &&
+    !mongoose.isValidObjectId(request.body.currentUser)
+  ) {
+    response.status(400).json({ error: 'Current user must be a valid MongoDB identifier.' });
+    return;
+  }
+
+  if (
+    request.body.currentBalance !== undefined &&
+    !isNonNegativeIntegerOrNumber(request.body.currentBalance)
+  ) {
+    response.status(400).json({ error: 'Current balance must be a non-negative number.' });
+    return;
+  }
+
+  if (
+    request.body.cosmeticCurrency !== undefined &&
+    !isNonNegativeIntegerOrNumber(request.body.cosmeticCurrency)
+  ) {
+    response.status(400).json({ error: 'Cosmetic currency must be a non-negative number.' });
+    return;
+  }
+
+  if (
+    request.body.currentDailyStreakCount !== undefined &&
+    !isNonNegativeIntegerOrNumber(request.body.currentDailyStreakCount)
+  ) {
+    response.status(400).json({ error: 'Current daily streak count must be non-negative.' });
+    return;
+  }
+
+  if (
+    request.body.longestStreakCount !== undefined &&
+    !isNonNegativeIntegerOrNumber(request.body.longestStreakCount)
+  ) {
+    response.status(400).json({ error: 'Longest streak count must be non-negative.' });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Validates a MongoDB identifier path parameter.
+ *
+ * @param {Request} request - Express request containing a route `id`.
+ * @param {Response} response - Express response used for validation failures.
+ * @param {NextFunction} next - Express continuation callback.
+ * @returns {void}
+ */
+export function validateAccountDataId(
+  request: Request,
+  response: Response,
+  next: NextFunction
+) {
+  if (!mongoose.isValidObjectId(request.params.id)) {
+    response.status(400).json({ error: 'A valid MongoDB identifier is required.' });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Determines whether the supplied value is a non-negative number.
+ *
+ * @param {unknown} value - Candidate request value.
+ * @returns {boolean} True when the value is a non-negative finite number.
+ */
+function isNonNegativeIntegerOrNumber(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+/**
+ * Determines whether the request body contains only supported fields.
+ *
+ * @param {Record<string, unknown>} body - Request body payload.
+ * @param {string[]} allowedKeys - Keys accepted by the validator.
+ * @returns {boolean} True when every key is supported.
+ */
+function hasSupportedKeys(body: Record<string, unknown>, allowedKeys: string[]) {
+  return Object.keys(body).every((key) => allowedKeys.includes(key));
+}

--- a/backend/validators/friends.validator.ts
+++ b/backend/validators/friends.validator.ts
@@ -1,0 +1,96 @@
+import type { NextFunction, Request, Response } from 'express';
+import mongoose from 'mongoose';
+
+/**
+ * Validates the request body used to create a friends document.
+ *
+ * @param {Request} request - Express request containing friend-list data.
+ * @param {Response} response - Express response used for validation failures.
+ * @param {NextFunction} next - Express continuation callback.
+ * @returns {void}
+ */
+export function validateCreateFriends(
+  request: Request,
+  response: Response,
+  next: NextFunction
+) {
+  const { currentUser, friends } = request.body;
+
+  if (!mongoose.isValidObjectId(currentUser)) {
+    response.status(400).json({ error: 'Current user must be a valid MongoDB identifier.' });
+    return;
+  }
+
+  if (!Array.isArray(friends) || !friends.every((friendId) => mongoose.isValidObjectId(friendId))) {
+    response.status(400).json({ error: 'Friends must be an array of MongoDB identifiers.' });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Validates the request body used to update a friends document.
+ *
+ * @param {Request} request - Express request containing partial friend-list data.
+ * @param {Response} response - Express response used for validation failures.
+ * @param {NextFunction} next - Express continuation callback.
+ * @returns {void}
+ */
+export function validateUpdateFriends(
+  request: Request,
+  response: Response,
+  next: NextFunction
+) {
+  const allowedKeys = ['currentUser', 'friends'];
+
+  if (Object.keys(request.body).length === 0) {
+    response.status(400).json({ error: 'At least one friends field is required.' });
+    return;
+  }
+
+  if (!Object.keys(request.body).every((key) => allowedKeys.includes(key))) {
+    response.status(400).json({ error: 'Request contains unsupported friends fields.' });
+    return;
+  }
+
+  if (
+    request.body.currentUser !== undefined &&
+    !mongoose.isValidObjectId(request.body.currentUser)
+  ) {
+    response.status(400).json({ error: 'Current user must be a valid MongoDB identifier.' });
+    return;
+  }
+
+  if (
+    request.body.friends !== undefined &&
+    (!Array.isArray(request.body.friends) ||
+      !request.body.friends.every((friendId: unknown) => mongoose.isValidObjectId(friendId)))
+  ) {
+    response.status(400).json({ error: 'Friends must be an array of MongoDB identifiers.' });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Validates a MongoDB identifier path parameter.
+ *
+ * @param {Request} request - Express request containing a route `id`.
+ * @param {Response} response - Express response used for validation failures.
+ * @param {NextFunction} next - Express continuation callback.
+ * @returns {void}
+ */
+export function validateFriendsId(
+  request: Request,
+  response: Response,
+  next: NextFunction
+) {
+  if (!mongoose.isValidObjectId(request.params.id)) {
+    response.status(400).json({ error: 'A valid MongoDB identifier is required.' });
+    return;
+  }
+
+  next();
+}

--- a/backend/validators/game.validator.ts
+++ b/backend/validators/game.validator.ts
@@ -1,0 +1,122 @@
+import type { NextFunction, Request, Response } from 'express';
+import mongoose from 'mongoose';
+
+/**
+ * Validates the request body used to create a game record.
+ *
+ * @param {Request} request - Express request containing game data.
+ * @param {Response} response - Express response used for validation failures.
+ * @param {NextFunction} next - Express continuation callback.
+ * @returns {void}
+ */
+export function validateCreateGame(
+  request: Request,
+  response: Response,
+  next: NextFunction
+) {
+  const { player, amountWagered, amountWonLost } = request.body;
+
+  if (!mongoose.isValidObjectId(player)) {
+    response.status(400).json({ error: 'Player must be a valid MongoDB identifier.' });
+    return;
+  }
+
+  if (!isNonNegativeNumber(amountWagered)) {
+    response.status(400).json({ error: 'Amount wagered must be a non-negative number.' });
+    return;
+  }
+
+  if (!isNumber(amountWonLost)) {
+    response.status(400).json({ error: 'Amount won or lost must be a number.' });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Validates the request body used to update a game record.
+ *
+ * @param {Request} request - Express request containing partial game data.
+ * @param {Response} response - Express response used for validation failures.
+ * @param {NextFunction} next - Express continuation callback.
+ * @returns {void}
+ */
+export function validateUpdateGame(
+  request: Request,
+  response: Response,
+  next: NextFunction
+) {
+  const allowedKeys = ['player', 'amountWagered', 'amountWonLost'];
+
+  if (Object.keys(request.body).length === 0) {
+    response.status(400).json({ error: 'At least one game field is required.' });
+    return;
+  }
+
+  if (!Object.keys(request.body).every((key) => allowedKeys.includes(key))) {
+    response.status(400).json({ error: 'Request contains unsupported game fields.' });
+    return;
+  }
+
+  if (request.body.player !== undefined && !mongoose.isValidObjectId(request.body.player)) {
+    response.status(400).json({ error: 'Player must be a valid MongoDB identifier.' });
+    return;
+  }
+
+  if (
+    request.body.amountWagered !== undefined &&
+    !isNonNegativeNumber(request.body.amountWagered)
+  ) {
+    response.status(400).json({ error: 'Amount wagered must be a non-negative number.' });
+    return;
+  }
+
+  if (request.body.amountWonLost !== undefined && !isNumber(request.body.amountWonLost)) {
+    response.status(400).json({ error: 'Amount won or lost must be a number.' });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Validates a MongoDB identifier path parameter.
+ *
+ * @param {Request} request - Express request containing a route `id`.
+ * @param {Response} response - Express response used for validation failures.
+ * @param {NextFunction} next - Express continuation callback.
+ * @returns {void}
+ */
+export function validateGameId(
+  request: Request,
+  response: Response,
+  next: NextFunction
+) {
+  if (!mongoose.isValidObjectId(request.params.id)) {
+    response.status(400).json({ error: 'A valid MongoDB identifier is required.' });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Determines whether the supplied value is numeric.
+ *
+ * @param {unknown} value - Candidate request value.
+ * @returns {boolean} True when the value is a finite number.
+ */
+function isNumber(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+/**
+ * Determines whether the supplied value is a non-negative number.
+ *
+ * @param {unknown} value - Candidate request value.
+ * @returns {boolean} True when the value is a non-negative finite number.
+ */
+function isNonNegativeNumber(value: unknown) {
+  return isNumber(value) && value >= 0;
+}

--- a/backend/validators/user.validator.ts
+++ b/backend/validators/user.validator.ts
@@ -1,0 +1,172 @@
+import type { NextFunction, Request, Response } from 'express';
+import mongoose from 'mongoose';
+
+/**
+ * Validates the request body used to create a user.
+ *
+ * @param {Request} request - Express request containing user data.
+ * @param {Response} response - Express response used for validation failures.
+ * @param {NextFunction} next - Express continuation callback.
+ * @returns {void}
+ */
+export function validateCreateUser(
+  request: Request,
+  response: Response,
+  next: NextFunction
+) {
+  const { name, displayName, dateOfBirth, email, password } = request.body;
+
+  if (!isNonEmptyString(name)) {
+    response.status(400).json({ error: 'Name is required.' });
+    return;
+  }
+
+  if (!isNonEmptyString(displayName)) {
+    response.status(400).json({ error: 'Display name is required.' });
+    return;
+  }
+
+  if (!isValidDate(dateOfBirth)) {
+    response.status(400).json({ error: 'A valid date of birth is required.' });
+    return;
+  }
+
+  if (!isValidEmail(email)) {
+    response.status(400).json({ error: 'A valid email address is required.' });
+    return;
+  }
+
+  if (!isStrongEnoughPassword(password)) {
+    response.status(400).json({ error: 'Password must be at least 8 characters long.' });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Validates the request body used to update a user.
+ *
+ * @param {Request} request - Express request containing partial user data.
+ * @param {Response} response - Express response used for validation failures.
+ * @param {NextFunction} next - Express continuation callback.
+ * @returns {void}
+ */
+export function validateUpdateUser(
+  request: Request,
+  response: Response,
+  next: NextFunction
+) {
+  const allowedKeys = ['name', 'displayName', 'dateOfBirth', 'email', 'password'];
+  const bodyKeys = Object.keys(request.body);
+
+  if (bodyKeys.length === 0) {
+    response.status(400).json({ error: 'At least one user field is required.' });
+    return;
+  }
+
+  if (bodyKeys.some((key) => !allowedKeys.includes(key))) {
+    response.status(400).json({ error: 'Request contains unsupported user fields.' });
+    return;
+  }
+
+  if (request.body.name !== undefined && !isNonEmptyString(request.body.name)) {
+    response.status(400).json({ error: 'Name must be a non-empty string.' });
+    return;
+  }
+
+  if (
+    request.body.displayName !== undefined &&
+    !isNonEmptyString(request.body.displayName)
+  ) {
+    response.status(400).json({ error: 'Display name must be a non-empty string.' });
+    return;
+  }
+
+  if (request.body.dateOfBirth !== undefined && !isValidDate(request.body.dateOfBirth)) {
+    response.status(400).json({ error: 'Date of birth must be a valid date.' });
+    return;
+  }
+
+  if (request.body.email !== undefined && !isValidEmail(request.body.email)) {
+    response.status(400).json({ error: 'Email must be a valid email address.' });
+    return;
+  }
+
+  if (
+    request.body.password !== undefined &&
+    !isStrongEnoughPassword(request.body.password)
+  ) {
+    response.status(400).json({ error: 'Password must be at least 8 characters long.' });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Validates a MongoDB identifier path parameter.
+ *
+ * @param {Request} request - Express request containing a route `id`.
+ * @param {Response} response - Express response used for validation failures.
+ * @param {NextFunction} next - Express continuation callback.
+ * @returns {void}
+ */
+export function validateMongoId(
+  request: Request,
+  response: Response,
+  next: NextFunction
+) {
+  if (!mongoose.isValidObjectId(request.params.id)) {
+    response.status(400).json({ error: 'A valid MongoDB identifier is required.' });
+    return;
+  }
+
+  next();
+}
+
+/**
+ * Determines whether the value is a non-empty string.
+ *
+ * @param {unknown} value - Candidate request value.
+ * @returns {boolean} True when the value is a non-empty string.
+ */
+function isNonEmptyString(value: unknown) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/**
+ * Determines whether the value is a valid ISO-compatible date input.
+ *
+ * @param {unknown} value - Candidate request value.
+ * @returns {boolean} True when the value can be parsed into a Date.
+ */
+function isValidDate(value: unknown) {
+  return (
+    value instanceof Date ||
+    (typeof value === 'string' && !Number.isNaN(new Date(value).getTime()))
+  );
+}
+
+/**
+ * Determines whether the value looks like an email address.
+ *
+ * @param {unknown} value - Candidate request value.
+ * @returns {boolean} True when the value matches a basic email pattern.
+ */
+function isValidEmail(value: unknown) {
+  return (
+    typeof value === 'string' &&
+    /^[^\s@]+@[^\s@]+\.[^\s@]+$/u.test(value)
+  );
+}
+
+/**
+ * Determines whether the supplied password satisfies minimum requirements.
+ *
+ * @param {unknown} value - Candidate password input.
+ * @returns {boolean} True when the password is acceptable.
+ */
+function isStrongEnoughPassword(value: unknown) {
+  return typeof value === 'string' && value.length >= 8;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "1.0.0",
       "dependencies": {
         "bcryptjs": "^3.0.2",
+        "express": "^5.1.0",
         "mongoose": "^8.19.3"
       },
       "devDependencies": {
+        "@types/express": "^5.0.3",
         "@types/node": "^24.6.0",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3"
@@ -468,6 +470,59 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.12.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
@@ -476,6 +531,41 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@types/webidl-conversions": {
@@ -493,6 +583,19 @@
         "@types/webidl-conversions": "*"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/bcryptjs": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
@@ -502,6 +605,30 @@
         "bcrypt": "bin/bcrypt"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bson": {
       "version": "6.10.4",
       "resolved": "https://registry.npmjs.org/bson/-/bson-6.10.4.tgz",
@@ -509,6 +636,84 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/debug": {
@@ -526,6 +731,74 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -570,6 +843,103 @@
         "@esbuild/win32-x64": "0.27.7"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -585,6 +955,52 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-tsconfig": {
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
@@ -598,6 +1014,99 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/kareem": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
@@ -607,11 +1116,66 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "license": "MIT"
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/mongodb": {
       "version": "6.20.0",
@@ -718,6 +1282,80 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -725,6 +1363,45 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -735,6 +1412,151 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/sift": {
@@ -750,6 +1572,24 @@
       "license": "MIT",
       "dependencies": {
         "memory-pager": "^1.0.2"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/tr46": {
@@ -784,6 +1624,20 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -804,6 +1658,24 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
@@ -826,6 +1698,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,11 @@
   },
   "dependencies": {
     "bcryptjs": "^3.0.2",
+    "express": "^5.1.0",
     "mongoose": "^8.19.3"
   },
   "devDependencies": {
+    "@types/express": "^5.0.3",
     "@types/node": "^24.6.0",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3"

--- a/tests/backend/controllers.test.ts
+++ b/tests/backend/controllers.test.ts
@@ -1,0 +1,78 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createUser, deleteUser } from '../../backend/controllers/user.controller.js';
+import { UserModel } from '../../backend/models/user.model.js';
+
+test('createUser hashes the password and returns a sanitized payload', async () => {
+  const originalSave = UserModel.prototype.save;
+
+  UserModel.prototype.save = async function saveStub() {
+    return this;
+  };
+
+  const response = createResponse();
+
+  await createUser(
+    {
+      body: {
+        name: 'Jane Player',
+        displayName: 'LuckyJane',
+        dateOfBirth: '1998-04-16',
+        email: 'jane@example.com',
+        password: 'slotspin123'
+      }
+    } as never,
+    response as never
+  );
+
+  UserModel.prototype.save = originalSave;
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(typeof (response.body as Record<string, unknown>).email, 'string');
+  assert.equal('passwordHash' in (response.body as Record<string, unknown>), false);
+});
+
+test('deleteUser returns 404 when the target user does not exist', async () => {
+  const originalDelete = UserModel.findByIdAndDelete;
+
+  UserModel.findByIdAndDelete = (() => ({
+    lean: async () => null
+  })) as typeof UserModel.findByIdAndDelete;
+
+  const response = createResponse();
+
+  await deleteUser(
+    {
+      params: {
+        id: '507f1f77bcf86cd799439011'
+      }
+    } as never,
+    response as never
+  );
+
+  UserModel.findByIdAndDelete = originalDelete;
+
+  assert.equal(response.statusCode, 404);
+  assert.deepEqual(response.body, { error: 'User not found.' });
+});
+
+/**
+ * Creates a lightweight Express-style response object for controller tests.
+ *
+ * @returns {{ statusCode: number; body: unknown; status(code: number): { json(payload: unknown): void } }} Mock response object.
+ */
+function createResponse() {
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return {
+        json: (payload: unknown) => {
+          this.body = payload;
+        }
+      };
+    }
+  };
+}

--- a/tests/backend/validators.test.ts
+++ b/tests/backend/validators.test.ts
@@ -1,0 +1,242 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import mongoose from 'mongoose';
+
+import {
+  validateCreateAccountData,
+  validateUpdateAccountData
+} from '../../backend/validators/account-data.validator.js';
+import {
+  validateCreateFriends,
+  validateFriendsId
+} from '../../backend/validators/friends.validator.js';
+import {
+  validateCreateGame,
+  validateUpdateGame
+} from '../../backend/validators/game.validator.js';
+import {
+  validateCreateUser,
+  validateMongoId,
+  validateUpdateUser
+} from '../../backend/validators/user.validator.js';
+
+test('validateCreateUser accepts a complete user payload', () => {
+  let nextCalled = false;
+
+  validateCreateUser(
+    createRequest({
+      body: {
+        name: 'Jane Player',
+        displayName: 'LuckyJane',
+        dateOfBirth: '1998-04-16',
+        email: 'jane@example.com',
+        password: 'slotspin123'
+      }
+    }),
+    createResponse(),
+    () => {
+      nextCalled = true;
+    }
+  );
+
+  assert.equal(nextCalled, true);
+});
+
+test('validateUpdateUser rejects unsupported fields', () => {
+  const response = createResponse();
+
+  validateUpdateUser(
+    createRequest({
+      body: {
+        unsupported: true
+      }
+    }),
+    response,
+    () => {
+      throw new Error('next should not be called');
+    }
+  );
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(response.body, {
+    error: 'Request contains unsupported user fields.'
+  });
+});
+
+test('validateMongoId rejects invalid object ids', () => {
+  const response = createResponse();
+
+  validateMongoId(
+    createRequest({
+      params: {
+        id: 'not-an-id'
+      }
+    }),
+    response,
+    () => {
+      throw new Error('next should not be called');
+    }
+  );
+
+  assert.equal(response.statusCode, 400);
+});
+
+test('validateCreateAccountData rejects negative balances', () => {
+  const response = createResponse();
+
+  validateCreateAccountData(
+    createRequest({
+      body: {
+        currentUser: new mongoose.Types.ObjectId().toString(),
+        currentBalance: -10,
+        cosmeticCurrency: 0,
+        currentDailyStreakCount: 0,
+        longestStreakCount: 0
+      }
+    }),
+    response,
+    () => {
+      throw new Error('next should not be called');
+    }
+  );
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(response.body, {
+    error: 'Current balance must be a non-negative number.'
+  });
+});
+
+test('validateUpdateAccountData accepts partial valid updates', () => {
+  let nextCalled = false;
+
+  validateUpdateAccountData(
+    createRequest({
+      body: {
+        cosmeticCurrency: 25
+      }
+    }),
+    createResponse(),
+    () => {
+      nextCalled = true;
+    }
+  );
+
+  assert.equal(nextCalled, true);
+});
+
+test('validateCreateFriends accepts valid user and friend ids', () => {
+  let nextCalled = false;
+
+  validateCreateFriends(
+    createRequest({
+      body: {
+        currentUser: new mongoose.Types.ObjectId().toString(),
+        friends: [
+          new mongoose.Types.ObjectId().toString(),
+          new mongoose.Types.ObjectId().toString()
+        ]
+      }
+    }),
+    createResponse(),
+    () => {
+      nextCalled = true;
+    }
+  );
+
+  assert.equal(nextCalled, true);
+});
+
+test('validateFriendsId rejects invalid ids', () => {
+  const response = createResponse();
+
+  validateFriendsId(
+    createRequest({
+      params: {
+        id: 'bad'
+      }
+    }),
+    response,
+    () => {
+      throw new Error('next should not be called');
+    }
+  );
+
+  assert.equal(response.statusCode, 400);
+});
+
+test('validateCreateGame rejects invalid wager values', () => {
+  const response = createResponse();
+
+  validateCreateGame(
+    createRequest({
+      body: {
+        player: new mongoose.Types.ObjectId().toString(),
+        amountWagered: -1,
+        amountWonLost: 5
+      }
+    }),
+    response,
+    () => {
+      throw new Error('next should not be called');
+    }
+  );
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(response.body, {
+    error: 'Amount wagered must be a non-negative number.'
+  });
+});
+
+test('validateUpdateGame accepts partial numeric updates', () => {
+  let nextCalled = false;
+
+  validateUpdateGame(
+    createRequest({
+      body: {
+        amountWonLost: -50
+      }
+    }),
+    createResponse(),
+    () => {
+      nextCalled = true;
+    }
+  );
+
+  assert.equal(nextCalled, true);
+});
+
+/**
+ * Creates a lightweight Express-style request object for middleware tests.
+ *
+ * @param {{ body?: Record<string, unknown>; params?: Record<string, string> }} options - Request shape overrides.
+ * @returns {{ body: Record<string, unknown>; params: Record<string, string> }} Mock request object.
+ */
+function createRequest(options: {
+  body?: Record<string, unknown>;
+  params?: Record<string, string>;
+}) {
+  return {
+    body: options.body ?? {},
+    params: options.params ?? {}
+  };
+}
+
+/**
+ * Creates a lightweight Express-style response object for middleware tests.
+ *
+ * @returns {{ statusCode: number; body: unknown; status(code: number): { json(payload: unknown): void } }} Mock response object.
+ */
+function createResponse() {
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return {
+        json: (payload: unknown) => {
+          this.body = payload;
+        }
+      };
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- add Express app wiring plus per-model controller, validator, and route files for users, account data, friends, and games
- validate request bodies and MongoDB ids before controller execution and map common persistence errors to API responses
- add unit tests covering controller behavior and validator edge cases

## Testing
- `npm test`

Closes #14