### PR TITLE
[codex] Update login page with pirate slot theming

### DIFF
--- a/frontend/components/auth/AuthShell.tsx
+++ b/frontend/components/auth/AuthShell.tsx
@@ -1,4 +1,5 @@
 import styles from '../../pages/App.module.css';
+import { authAccessModeHighlights, loginMarqueeSymbols } from './auth-content.js';
 import type { FormMode } from './auth-types.js';
 
 interface AuthShellProps {
@@ -37,10 +38,12 @@ export function AuthShell({
           </p>
         </div>
         <div className={styles.marqueeStrip} aria-hidden="true">
-          <span className={styles.marqueeItem}>777</span>
-          <span className={styles.marqueeItem}>BAR</span>
-          <span className={styles.marqueeItem}>CHERRY</span>
-          <span className={styles.marqueeItem}>JACKPOT</span>
+          {loginMarqueeSymbols.map((symbolDisplay) => (
+            <span className={styles.marqueeItem} key={symbolDisplay.alt}>
+              <img alt="" className={styles.marqueeIcon} src={symbolDisplay.assetUrl} />
+              <span className={styles.marqueeLabel}>{symbolDisplay.alt}</span>
+            </span>
+          ))}
         </div>
       </section>
 
@@ -49,9 +52,9 @@ export function AuthShell({
           <p className={styles.eyebrow}>Access modes</p>
           <h2 className={styles.sectionTitle}>Front-of-house now, full casino later.</h2>
           <ul className={styles.featureList}>
-            <li>Email login with cached session restore on this device</li>
-            <li>Signup flow with confirm password, date of birth, and captcha prompt</li>
-            <li>Guest lane for players who want a quick look first</li>
+            {authAccessModeHighlights.map((highlight) => (
+              <li key={highlight}>{highlight}</li>
+            ))}
           </ul>
           <p className={styles.feedbackBanner}>{feedbackMessage}</p>
         </aside>

--- a/frontend/components/auth/auth-content.ts
+++ b/frontend/components/auth/auth-content.ts
@@ -1,0 +1,12 @@
+import { pirateTreasureTheme } from '../home/slot-theme.js';
+
+export const loginMarqueeSymbols = [
+  pirateTreasureTheme.symbolDisplayMap.seven,
+  pirateTreasureTheme.symbolDisplayMap.diamond,
+  pirateTreasureTheme.symbolDisplayMap.bar,
+  pirateTreasureTheme.symbolDisplayMap.cherry,
+  pirateTreasureTheme.symbolDisplayMap.bell,
+  pirateTreasureTheme.symbolDisplayMap.horseshoe
+] as const;
+
+export const authAccessModeHighlights = ['Sign up now or login', 'You can also play as a guest'] as const;

--- a/frontend/pages/App.module.css
+++ b/frontend/pages/App.module.css
@@ -87,11 +87,27 @@
 }
 
 .marqueeItem {
+  min-width: 110px;
   padding: 10px 14px;
   border: 1px solid rgba(255, 214, 153, 0.2);
   color: #ffde9d;
   background: rgba(255, 248, 220, 0.06);
+  display: grid;
+  justify-items: center;
+  gap: 10px;
+  text-align: center;
   animation: pulseGlow 3.6s ease-in-out infinite;
+}
+
+.marqueeIcon {
+  width: 44px;
+  height: 44px;
+  object-fit: contain;
+}
+
+.marqueeLabel {
+  font-size: 0.88rem;
+  line-height: 1.2;
 }
 
 .marqueeItem:nth-child(2) {

--- a/tests/frontend/auth-shell.test.ts
+++ b/tests/frontend/auth-shell.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { authAccessModeHighlights, loginMarqueeSymbols } from '../../frontend/components/auth/auth-content.js';
+
+test('auth access-mode copy advertises login or signup plus guest play', () => {
+  assert.deepEqual([...authAccessModeHighlights], ['Sign up now or login', 'You can also play as a guest']);
+});
+
+test('login marquee uses six pirate slot-machine art symbols', () => {
+  assert.equal(loginMarqueeSymbols.length, 6);
+
+  for (const symbolDisplay of loginMarqueeSymbols) {
+    assert.ok(symbolDisplay.assetUrl);
+    assert.ok(symbolDisplay.alt.length > 0);
+  }
+});


### PR DESCRIPTION
## What changed
- replaced the login-page marquee text tokens with the pirate slot machine's symbol art so the auth hero matches the pirate machine theme
- updated the access-mode bullet copy to `Sign up now or login` and `You can also play as a guest`
- added a focused frontend regression test for the login-page copy and pirate symbol set

## Why
The login page was still using generic slot text symbols and outdated access-mode copy instead of the pirate-themed assets shown elsewhere in the app.

## Impact
Players now see pirate-themed login visuals and the requested simplified access messaging before entering the app.

## Validation
- `./node_modules/.bin/tsx.cmd --test tests/frontend/auth-shell.test.ts`
- `npm.cmd run build`