### PR TITLE
Document plain TypeScript source modules

### DIFF
--- a/backend/models/index.ts
+++ b/backend/models/index.ts
@@ -1,3 +1,7 @@
+/**
+ * Re-exports the Mongoose models used throughout the backend so callers can import
+ * from one module instead of referencing each model file directly.
+ */
 export { AccountDataModel } from './account-data.model.js';
 export { FriendsModel } from './friends.model.js';
 export { GameModel } from './game.model.js';

--- a/backend/routes/account-data.routes.ts
+++ b/backend/routes/account-data.routes.ts
@@ -13,6 +13,9 @@ import {
   validateUpdateAccountData
 } from '../validators/account-data.validator.js';
 
+/**
+ * Express router exposing CRUD endpoints for persisted account-data records.
+ */
 export const accountDataRouter = Router();
 
 accountDataRouter.get('/', listAccountData);

--- a/backend/routes/auth.routes.ts
+++ b/backend/routes/auth.routes.ts
@@ -11,6 +11,9 @@ import {
   validateSignupRequest
 } from '../validators/auth.validator.js';
 
+/**
+ * Express router for signup, login, guest login, and session restoration endpoints.
+ */
 export const authRouter = Router();
 
 authRouter.post('/signup', validateSignupRequest, signup);

--- a/backend/routes/friends.routes.ts
+++ b/backend/routes/friends.routes.ts
@@ -13,6 +13,9 @@ import {
   validateUpdateFriends
 } from '../validators/friends.validator.js';
 
+/**
+ * Express router exposing CRUD endpoints for user friend-list documents.
+ */
 export const friendsRouter = Router();
 
 friendsRouter.get('/', listFriendsLists);

--- a/backend/routes/game.routes.ts
+++ b/backend/routes/game.routes.ts
@@ -13,6 +13,9 @@ import {
   validateUpdateGame
 } from '../validators/game.validator.js';
 
+/**
+ * Express router exposing CRUD endpoints for stored game-history records.
+ */
 export const gameRouter = Router();
 
 gameRouter.get('/', listGames);

--- a/backend/routes/leaderboard.routes.ts
+++ b/backend/routes/leaderboard.routes.ts
@@ -2,6 +2,9 @@ import { Router } from 'express';
 
 import { listLeaderboard } from '../controllers/leaderboard.controller.js';
 
+/**
+ * Express router for the public leaderboard feed ordered by player balance.
+ */
 export const leaderboardRouter = Router();
 
 leaderboardRouter.get('/', listLeaderboard);

--- a/backend/routes/slot-machine.routes.ts
+++ b/backend/routes/slot-machine.routes.ts
@@ -8,6 +8,9 @@ import {
   updateSlotMachineBetAmountController
 } from '../controllers/slot-machine.controller.js';
 
+/**
+ * Express router for the connected slot-machine gameplay and prize endpoints.
+ */
 export const slotMachineRouter = Router();
 
 slotMachineRouter.get('/state', getCurrentSlotMachineState);

--- a/backend/routes/user.routes.ts
+++ b/backend/routes/user.routes.ts
@@ -13,6 +13,9 @@ import {
   validateUpdateUser
 } from '../validators/user.validator.js';
 
+/**
+ * Express router exposing CRUD endpoints for user profile records.
+ */
 export const userRouter = Router();
 
 userRouter.get('/', listUsers);

--- a/frontend/components/auth/auth-types.ts
+++ b/frontend/components/auth/auth-types.ts
@@ -1,10 +1,19 @@
+/**
+ * Supported auth surface modes for the login page.
+ */
 export type FormMode = 'login' | 'signup';
 
+/**
+ * Serializable form state for the login flow.
+ */
 export interface LoginFormState {
   email: string;
   password: string;
 }
 
+/**
+ * Serializable form state for the signup flow.
+ */
 export interface SignupFormState {
   name: string;
   displayName: string;
@@ -15,11 +24,17 @@ export interface SignupFormState {
   captcha: string;
 }
 
+/**
+ * Empty login-form defaults used when initializing or resetting the login view.
+ */
 export const initialLoginForm: LoginFormState = {
   email: '',
   password: ''
 };
 
+/**
+ * Empty signup-form defaults used when initializing or resetting the signup view.
+ */
 export const initialSignupForm: SignupFormState = {
   name: '',
   displayName: '',

--- a/frontend/components/home/slot-theme.ts
+++ b/frontend/components/home/slot-theme.ts
@@ -1,11 +1,17 @@
 import type { SlotSymbol } from '../../services/slot-machine-client.js';
 
+/**
+ * Render metadata for a single slot symbol in the active machine theme.
+ */
 export interface SlotSymbolDisplay {
   alt: string;
   assetUrl?: string;
   emblemText?: string;
 }
 
+/**
+ * Visual theme contract for a slot-machine cabinet and its symbol art.
+ */
 export interface SlotMachineTheme {
   accentLabel: string;
   jackpotLabels: Array<{
@@ -17,8 +23,17 @@ export interface SlotMachineTheme {
   symbolDisplayMap: Record<SlotSymbol, SlotSymbolDisplay>;
 }
 
+/**
+ * Resolves a bundled static asset URL relative to this theme module.
+ *
+ * @param {string} relativePath - Relative asset path under the repo asset folder.
+ * @returns {string} Browser-ready asset URL.
+ */
 const resolveAssetUrl = (relativePath: string) => new URL(relativePath, import.meta.url).href;
 
+/**
+ * Pirate-themed reel art and cabinet copy used by the connected home slot machine.
+ */
 export const pirateTreasureTheme: SlotMachineTheme = {
   machineName: 'Blackwater Bounty',
   accentLabel: 'Treasure deck',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
+/**
+ * Vite development and build configuration for the React frontend.
+ */
 export default defineConfig({
   plugins: [react()],
   server: {


### PR DESCRIPTION
## Summary
- add JSDoc comments to plain TypeScript source modules that were missing documentation
- document backend route modules and model re-exports
- document shared frontend auth/theme types and the Vite config

## Testing
- npm run lint
- npm run typecheck
- npm test